### PR TITLE
feat: upgrade nix version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ flurry = { version = "0.3.1", optional = true }
 tokio = { version = "1.14", optional = true, features = ["rt", "sync"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.19"
+nix = "0.24.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winerror", "winbase", "handleapi", "fileapi", "namedpipeapi"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,15 +242,14 @@ impl From<std::string::FromUtf8Error> for Error
 #[cfg(unix)]
 impl From<nix::Error> for Error
 {
-    fn from(error: nix::Error) -> Error
+    fn from(error: nix::Error) -> Self
     {
-        match error
-        {
-            nix::Error::InvalidPath => Error::InvalidPath,
-            nix::Error::InvalidUtf8 => Error::InvalidUtf8,
-            nix::Error::UnsupportedOperation => Error::InvalidPath,
-            nix::Error::Sys(errno) => Error::Native("", errno as u32, errno.desc().to_string())
-        }
+        // match error
+        // {
+        //     nix::Error::UnknownErrno => Error::InvalidPath,
+        //     _ => Error::Native("", errno as u32, errno.desc().to_string())
+        // }
+        Error::Io(std::io::Error::from_raw_os_error(error as i32))
     }
 }
 

--- a/src/pipe_unix.rs
+++ b/src/pipe_unix.rs
@@ -43,7 +43,7 @@ impl Pipe
                         Err(Error::InvalidPath)?;
                     }
                 },
-                Err(nix::Error::InvalidPath) | Err(nix::Error::Sys(Errno::ENOENT)) => 
+                Err(Errno::ENOENT) => 
                 {
                     unistd::mkfifo(path, mode)?;
                 },
@@ -117,7 +117,7 @@ impl Pipe
                     // Error out if file is not a named pipe
                     if file_stat.st_mode & SFlag::S_IFIFO.bits() == 0
                     {
-                        Err(nix::Error::InvalidPath)?;
+                        Err(nix::Error::ENOENT)?;
                     }
                 },
                 err => 
@@ -155,7 +155,7 @@ impl Pipe
                 self.handle2 = Some(handle);
             }
             self.handle2.as_ref().unwrap().raw()
-        }.ok_or(nix::Error::Sys(nix::errno::Errno::EBADF)).map_err(|e| e.into())
+        }.ok_or(nix::errno::Errno::EBADF).map_err(|e| e.into())
     }
 }
 


### PR DESCRIPTION
The original ipipe depended on the old nix version which caused a vulnerability on [our pipeline audit check](https://github.com/LitheumOrg/LitheumCore/runs/6145061721?check_suite_focus=true#step:5:18)

This PR served for upgrading nix version.
But this version won't have these error types anymore `nix::Error::InvalidPath`, `nix::Error::InvalidUtf8`  & `nix::Error::UnsupportedOperation`, for further details please check [this discussion](https://github.com/nix-rust/nix/issues/613).
TLDR: No conversion between `Errno` and `std::io::Error` anymore.
My changes are to adapt this, but im not sure if its enough. 
Please do a rough review. Thanks.